### PR TITLE
Switch to twit npm package

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,17 +10,10 @@ var async = require('async'),
     moment = require('moment'),
     startup = Date.now(),
     latest = 0,
-    twitter = require('ntwitter'),
+    twitter = require('twit'),
     twit,
     delay,
     queue;
-
-twit = twitter({
-  consumer_key: process.env.CONSUMER_KEY,
-  consumer_secret: process.env.CONSUMER_SECRET,
-  access_token_key: process.env.ACCESS_TOKEN,
-  access_token_secret: process.env.ACCESS_SECRET
-});
 
 try {
   env = fs.readFileSync('.env', 'utf8');
@@ -28,6 +21,13 @@ try {
 } catch(e) {
   // do nothing. normal in production
 }
+
+twit = twitter({
+  consumer_key: process.env.CONSUMER_KEY,
+  consumer_secret: process.env.CONSUMER_SECRET,
+  access_token: process.env.ACCESS_TOKEN,
+  access_token_secret: process.env.ACCESS_SECRET
+});
 
 console.log('CONSUMER_KEY: '+process.env.CONSUMER_KEY);
 console.log('CONSUMER_SECRET: '+(process.env.CONSUMER_SECRET != null));
@@ -97,7 +97,14 @@ function processEntry(entry, callback) {
       latest = ts;
     }
     if (process.env.NODE_ENV === 'production') {
-      twit.updateStatus(_s.prune(line, 140), callback);
+
+      twit.post('statuses/update', { status: _s.prune(line, 140) },
+        function(err, data, response) {
+          if(err) { console.error(err) };
+
+          callback();
+        });
+
     } else {
       console.log(_s.prune(line, 140));
       callback();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "request": "~2.21.0",
     "moment": "~2.0.0",
     "underscore.string": "~2.3.1",
-    "ntwitter": "~0.5.0",
+    "twit": "^2.2.5",
     "async": "~0.2.7"
   }
 }


### PR DESCRIPTION
`ntwitter` is deprecated and when testing in development I observed `215, message: 'Bad Authentication data.` errors.

The `twit` package seems to still be maintained.

This also logs errors.